### PR TITLE
Feat/andrew/load models

### DIFF
--- a/quickstart_finetune_load.py
+++ b/quickstart_finetune_load.py
@@ -1,0 +1,20 @@
+# import our client
+from llm_vm.client import Client
+import os
+
+# Instantiate the client specifying which LLM you want to use
+
+client = Client(big_model='pythia')
+print('Default load result')
+response = client.complete(prompt = 'what is anarchy?',
+                           context = '',)
+print(response)
+path_to_model = '~/.llm_vm/models/finetuned_models/pythia-70m-deduped/'
+model_name = '2023-07-19T22:42:35_pythia-70m-deduped.pt'
+client.load_finetune(model_name)
+print('Final Trial')
+# Put in your prompt and go!
+response2 = client.complete(prompt = 'What is anarchy?',
+                           context='')
+print(response2)
+# Anarchy is a political system in which the state is abolished and the people are free...

--- a/quickstart_finetune_load.py
+++ b/quickstart_finetune_load.py
@@ -6,7 +6,7 @@ import os
 client = Client(big_model='pythia')
 
 # specify the file name of the finetuned model to load
-model_name = '2023-07-19T22:42:35_pythia-70m-deduped.pt'
+model_name = '<filename_of_your_model>.pt'
 client.load_finetune(model_name)
 
 # Put in your prompt and go!

--- a/quickstart_finetune_load.py
+++ b/quickstart_finetune_load.py
@@ -3,18 +3,14 @@ from llm_vm.client import Client
 import os
 
 # Instantiate the client specifying which LLM you want to use
-
 client = Client(big_model='pythia')
-print('Default load result')
-response = client.complete(prompt = 'what is anarchy?',
-                           context = '',)
-print(response)
-path_to_model = '~/.llm_vm/models/finetuned_models/pythia-70m-deduped/'
+
+# specify the file name of the finetuned model to load
 model_name = '2023-07-19T22:42:35_pythia-70m-deduped.pt'
 client.load_finetune(model_name)
-print('Final Trial')
+
 # Put in your prompt and go!
-response2 = client.complete(prompt = 'What is anarchy?',
+response = client.complete(prompt = 'What is anarchy?',
                            context='')
-print(response2)
+print(response)
 # Anarchy is a political system in which the state is abolished and the people are free...

--- a/src/llm_vm/client.py
+++ b/src/llm_vm/client.py
@@ -59,18 +59,23 @@ class Client:
         print("Using model: " + big_model) # announce the primary LLM that is generating results
 
         # These functions allow for proper initialization of the optimizer
-        def CALL_BIG(prompt, max_len=256, **kwargs):
+        # def CALL_BIG(prompt, max_len=256, **kwargs):
             
-            return self.teacher.generate(prompt, max_len,**kwargs)
+        #     return self.teacher.generate(prompt, max_len,**kwargs)
 
         def CALL_SMALL(prompt, max_len=256, **kwargs):
            
             return self.student.generate(prompt, max_len,**kwargs)
         
         # load the optimizer into object memory for use by the complete function
-        self.optimizer = LocalOptimizer(MIN_TRAIN_EXS=2,openai_key=None, call_big=CALL_BIG, call_small= CALL_SMALL, 
+        self.optimizer = LocalOptimizer(MIN_TRAIN_EXS=2,openai_key=None, call_big=self.CALL_BIG, call_small= CALL_SMALL, 
                                         big_model = self.teacher, small_model = self.student)
         self.rebel_agent = agent.Agent("", [], verbose=1)
+
+    # These functions allow for proper initialization of the optimizer
+    def CALL_BIG(self, prompt, max_len=256, **kwargs):
+        
+        return self.teacher.generate(prompt, max_len,**kwargs)
     
     def complete(self, prompt,
                  context,
@@ -151,3 +156,9 @@ class Client:
             return {"status":0, "resp": str(e)}
         return {"completion":completion, "status": 200}
 
+    def load_finetune(self, model_filename=None):
+        print('Parent Model response:')
+        print(self.CALL_BIG('run this test'))
+        self.teacher.load_finetune(model_filename)
+        print('Client model response:')
+        print(self.complete(prompt = 'run this test', context = ''))

--- a/src/llm_vm/client.py
+++ b/src/llm_vm/client.py
@@ -157,8 +157,5 @@ class Client:
         return {"completion":completion, "status": 200}
 
     def load_finetune(self, model_filename=None):
-        print('Parent Model response:')
-        print(self.CALL_BIG('run this test'))
         self.teacher.load_finetune(model_filename)
-        print('Client model response:')
-        print(self.complete(prompt = 'run this test', context = ''))
+       

--- a/src/llm_vm/onsite_llm.py
+++ b/src/llm_vm/onsite_llm.py
@@ -79,7 +79,17 @@ class Base_Onsite_LLM(ABC):
     def tokenizer_loader(self):
         pass
 
-    
+    def load_finetune(self, model_filename):
+        self.model.load_state_dict(torch.load(os.path.join(model_path_default,"finetuned_models", self.model_name, model_filename)))
+        print('Testing finetune...')
+        inputs = self.tokenizer('run this test', return_tensors='pt')
+        generate_ids = self.model.generate(inputs.input_ids, max_length=100)
+        response = self.tokenizer.batch_decode(generate_ids,skip_special_tokens=True, clean_up_tokenization_spaces=False)
+        print('Fine tune response:')
+        print(response)
+        print('actual model response inside onsite_llm:')
+        print(self.generate('run this test'))
+        
     def generate(self,prompt,max_length=100,**kwargs): # both tokenizer and model take kwargs :(
         """
         This function uses the class's llm and tokenizer to generate a response given a user's prompt

--- a/src/llm_vm/onsite_llm.py
+++ b/src/llm_vm/onsite_llm.py
@@ -81,14 +81,7 @@ class Base_Onsite_LLM(ABC):
 
     def load_finetune(self, model_filename):
         self.model.load_state_dict(torch.load(os.path.join(model_path_default,"finetuned_models", self.model_name, model_filename)))
-        print('Testing finetune...')
-        inputs = self.tokenizer('run this test', return_tensors='pt')
-        generate_ids = self.model.generate(inputs.input_ids, max_length=100)
-        response = self.tokenizer.batch_decode(generate_ids,skip_special_tokens=True, clean_up_tokenization_spaces=False)
-        print('Fine tune response:')
-        print(response)
-        print('actual model response inside onsite_llm:')
-        print(self.generate('run this test'))
+       
         
     def generate(self,prompt,max_length=100,**kwargs): # both tokenizer and model take kwargs :(
         """


### PR DESCRIPTION
I believe I've added code that will allow us to load finetuned models into the optimizer for immediate use.
This is working on my machine loading the pythia models I "fine tuned" in earlier runs of development. Run quickstart_finetune_load.py to test, comment out line 10 to see difference between parent model and finetune model. 
The answers the finetune spits out are completely non-sensical, but it was finetuned on quick/dirty trial run data, so this makes sense. What matters is it's response to the prompt is completely different than the default loaded model, which I take as an indication this code is working as intended.