### PR TITLE
Update onsite_llm.py

### DIFF
--- a/src/llm_vm/onsite_llm.py
+++ b/src/llm_vm/onsite_llm.py
@@ -12,6 +12,8 @@ from transformers import (
     BloomForCausalLM,
     GPTNeoForCausalLM,
     GPTNeoXForCausalLM,
+    LlamaForCausalLM,
+    LlamaTokenizer,
     GPT2Tokenizer,
     DataCollatorForLanguageModeling,
     TrainingArguments,


### PR DESCRIPTION
This edit is for fixing the issue "LlamaForCausalLM" is not defined #183

The name LlamaforCasualLm was not imported from the transformers library and thus it was shown as not defined.