### PR TITLE
fix: chatgpt finetune model changed to gpt-3.5-turbo-0613

### DIFF
--- a/src/llm_vm/onsite_llm.py
+++ b/src/llm_vm/onsite_llm.py
@@ -1,4 +1,3 @@
-import abc
 from abc import ABC,abstractmethod
 import sys
 import openai
@@ -7,16 +6,12 @@ from transformers import (
     AutoModelForMaskedLM,
     AutoModelForSeq2SeqLM,
     AutoTokenizer,
-    BertTokenizer,
     OPTForCausalLM,
     BloomForCausalLM,
-    LlamaTokenizer,
-    LlamaForCausalLM,
     GPTNeoForCausalLM,
     GPTNeoXForCausalLM,
     LlamaForCausalLM,
     LlamaTokenizer,
-    GPT2Tokenizer,
     DataCollatorForLanguageModeling,
     TrainingArguments,
     Trainer)
@@ -281,7 +276,7 @@ class Small_Local_Neo(Base_Onsite_LLM):
     def model_loader(self):
         return GPTNeoForCausalLM.from_pretrained(self.model_uri)
     def tokenizer_loader(self):
-        return GPT2Tokenizer.from_pretrained(self.model_uri)
+        return AutoTokenizer.from_pretrained(self.model_uri)
 
 @RegisterModelClass("llama")
 class Small_Local_OpenLLama(Base_Onsite_LLM):
@@ -374,7 +369,7 @@ class Small_Local_BERT(Base_Onsite_LLM):
     def model_loader(self):
         return AutoModelForMaskedLM.from_pretrained(self.model_uri)
     def tokenizer_loader(self):
-        return BertTokenizer.from_pretrained(self.model_uri)
+        return AutoTokenizer.from_pretrained(self.model_uri)
 @RegisterModelClass("gpt")
 class GPT3:
 
@@ -409,7 +404,7 @@ class GPT3:
     def finetune(self, dataset, optimizer, c_id):
         old_model = optimizer.storage.get_model(c_id)
         training_file = create_jsonl_file(dataset)
-        upload_response = openai.File.create(file=training_file, purpose="fine-tune")
+        upload_response = openai.File.create(file=training_file, purpose="fine-tune", model="gpt-3.5-turbo-0613")
         training_file.close()
         fine_tuning_job = openai.FineTune.create(training_file= upload_response.id)
 


### PR DESCRIPTION
close #167 

- removed unused and duplicated imports
- specific tokenizers changed to autotokenizers 
	-	[Proof of `autotokenizer.from_pretrained` supports `GPT2Tokenizer` and `BertTokenizer`](https://huggingface.co/transformers/v3.0.2/model_doc/auto.html#transformers.AutoTokenizer.from_pretrained)

```
Fine-tuning is currently available for the following models:

gpt-3.5-turbo-0613 (recommended)
babbage-002
davinci-002
```
[Source ↑](https://platform.openai.com/docs/guides/fine-tuning/what-models-can-be-fine-tuned) 

```
code-davinci-002 is a base model, so good for pure code-completion tasks
text-davinci-002 is an InstructGPT model based on code-davinci-002
text-davinci-003 is an improvement on text-davinci-002
gpt-3.5-turbo-0301 is an improvement on text-davinci-003, optimized for chat
```
[Source ↑](https://platform.openai.com/docs/model-index-for-researchers/models-referred-to-as-gpt-3-5)
