### PR TITLE
feat: added speculative sampling

### DIFF
--- a/examples/quickstart_speculative_sampling.py
+++ b/examples/quickstart_speculative_sampling.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+# import our client
+import sys
+from llm_vm.client import Client
+
+# Instantiate the client specifying which LLM you want to use
+
+client = Client(big_model='opt',
+                big_model_config={'model_uri': 'facebook/opt-350m'},
+                small_model='opt',
+                small_model_config={'model_uri': 'facebook/opt-125m'},
+                optimizer='speculative_sampling',
+                speculative_sampling_tokenizer="small",
+                speculative_sampling_version="deepmind"
+                )
+
+# Put in your prompt and go!
+response = client.complete(prompt = 'What is the capital of the USA?',
+                           context='')
+print(response, file=sys.stderr)
+# Anarchy is a political system in which the state is abolished and the people are free...

--- a/src/llm_vm/client.py
+++ b/src/llm_vm/client.py
@@ -1,12 +1,12 @@
 import sys
 import openai
-import llm_vm.onsite_llm as llms
 from llm_vm.onsite_llm import load_model_closure
 from llm_vm.agents.REBEL import agent
 from llm_vm.completion.optimize import LocalOptimizer
 import llm_vm.config as conf
 import os
 
+from llm_vm.utils.speculative_sampling import speculative_sampling, speculative_sampling_v2
 
 if conf.settings.big_model is None:
     default_big_model = "chat_gpt"
@@ -33,13 +33,19 @@ class Client:
         complete: The Anarchy completion endpoint giving access to a specified LLM
     """
 
-    def __init__(self, big_model = default_big_model, small_model =default_small_model,big_model_config={},small_model_config={}):
+    def __init__(self, big_model = default_big_model,
+                 small_model =default_small_model,big_model_config={},small_model_config={},
+                 optimizer="local_optimizer", speculative_sampling_tokenizer="small", speculative_sampling_version="google"):
         """
         This __init__ function allows the user to specify which LLM they want to use upon instantiation.
 
         Parameters:
             big_model (str): Name of LLM to be used as a reliable source
             small_model (str): Name of small model to be used for fine-tuning
+            optimizer (str): Name of optimizer ("local_optimizer" or "speculative_sampling")
+            speculative_sampling_tokenizer (str): Name of tokenizer to be used for speculative sampling because both
+                                                models should use the same tokenizer!  ("small" or "big")
+            speculative_sampling_version (str): Name of speculative sampling version to be used ("google" or "deepmind")
 
         Returns:
             None
@@ -68,10 +74,22 @@ class Client:
                 self.student.load_finetune(small_model_filename)
 
             return self.student.generate(prompt, max_len,**kwargs)
+        if optimizer == "local_optimizer":
+            # load the optimizer into object memory for use by the complete function
+            self.optimizer = LocalOptimizer(MIN_TRAIN_EXS=2,openai_key=None, call_big=self.CALL_BIG, call_small= CALL_SMALL,
+                                            big_model = self.teacher, small_model = self.student)
+        elif optimizer == "speculative_sampling":
+            self.optimizer = None
+            self.speculative_sampling_version = speculative_sampling_version
+            if speculative_sampling_tokenizer == 'small':
+                self.speculative_sampling_tokenizer = self.student.tokenizer
+            elif speculative_sampling_tokenizer == 'big':
+                self.speculative_sampling_tokenizer = self.teacher.tokenizer
+            else:
+                raise Exception("speculative_sampling_tokenizer must be either 'small' or 'big'")
+        else:
+            raise Exception("optimizer must be either 'local_optimizer' or 'speculative_sampling'")
 
-        # load the optimizer into object memory for use by the complete function
-        self.optimizer = LocalOptimizer(MIN_TRAIN_EXS=2,openai_key=None, call_big=self.CALL_BIG, call_small= CALL_SMALL,
-                                        big_model = self.teacher, small_model = self.student)
         self.rebel_agent = None # only initialized on first use
 
     # These functions allow for proper initialization of the optimizer
@@ -109,7 +127,12 @@ class Client:
         static_context = context
         dynamic_prompt = prompt
         use_rebel_agent = False
-
+        # TODO(us): speculative_sampling gives error when temp is 0,
+        # self.optimizer is None means `speculative_sampling` is used
+        if temperature == 0 and self.optimizer is None:
+            temperature = 0.2
+        else:
+            raise Exception("temperature can't only be 0 for speculative sampling")
         kwargs.update({"temperature":temperature})
 
         if openai_key is not None:
@@ -148,16 +171,27 @@ class Client:
         except:
             return  {"status":0, "resp":"Issue with OpenAI key"}
 
-        self.optimizer.openai_key = openai.api_key
-        # self.agent.set_api_key(openai.api_key,"OPENAI_API_KEY") #
+        if self.optimizer is not None:  # speculative sampling works only with onsite models!
+            self.optimizer.openai_key = openai.api_key
+        # self.agent.set_api_key(openai.api_key,"OPENAI_API_KEY") # 
+
         if os.getenv("OPENAI_API_KEY") is None and use_rebel_agent==True :
             print("warning: you need OPENAI_API_KEY environment variable for ", file=sys.stderr)
 
         try:
-            if not use_rebel_agent:
+            if not use_rebel_agent and isinstance(self.optimizer, LocalOptimizer):
                 completion = self.optimizer.complete(static_context,dynamic_prompt,data_synthesis=data_synthesis,finetune = finetune, **kwargs)
+            elif not use_rebel_agent and self.optimizer is None:
+                input_ids = self.speculative_sampling_tokenizer.encode(static_context+dynamic_prompt, return_tensors='pt')
+                if self.speculative_sampling_version == "google":
+                    output = speculative_sampling(input_ids, self.student.model, self.teacher.model, 256, temperature=temperature,
+                                                  top_k=10, top_p=0.9)  # temperature=0 gives this error `probability tensor contains either `inf`, `nan` or element < 0`
+                elif self.speculative_sampling_version == "deepmind":
+                    output = speculative_sampling_v2(input_ids, self.student.model, self.teacher.model,256, temperature=temperature)
+
+                completion = self.speculative_sampling_tokenizer.decode(output[0], skip_special_tokens=True)
             else:
-                completion = self.rebel_agent.run(static_context+dynamic_prompt,[])[0]
+                completion = self.rebel_agent.run(static_context+dynamic_prompt, [])[0]
         except Exception as e:
             return {"status":0, "resp": str(e)}
         return {"completion":completion, "status": 200}

--- a/src/llm_vm/utils/speculative_sampling.py
+++ b/src/llm_vm/utils/speculative_sampling.py
@@ -1,0 +1,402 @@
+"""
+Speculative Sampling
+from https://raw.githubusercontent.com/feifeibear/LLMSpeculativeSampling/main/sample.py
+"""
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from tqdm import tqdm
+import torch
+from torch.nn import functional as F
+import argparse
+from typing import Tuple
+
+
+class Decoder:
+    def __init__(self, tokenizer) -> None:
+        self.tokenizer = tokenizer
+
+    def decode(self, t: torch.Tensor) -> str:
+        # assert t.dim == 2, "t must be 2d tensor"
+        return self.tokenizer.decode(t[0], skip_special_tokens=True)
+
+
+DECODER: Decoder = None
+
+
+# copy from https://github.com/LeeSinLiang/microGPT/blob/ed40cf9780dbeb180adfe94c227d4aa97e69250e/gpt.py
+def top_k_top_p_filter(logits: torch.Tensor, top_k: int = 0, top_p: float = 0.0):
+    """
+
+    Args:
+        logits (torch.Tensorpe_): 2D tensor with shape (batch, vocab)
+        top_k (int, optional): top_k. Defaults to 0.
+        top_p (float, optional): top_p. Defaults to 0.0.
+
+    Returns:
+        torch.Tensor: a renormalized logits
+    """
+    if top_k > 0:
+        filter = torch.topk(logits, min(top_k, logits.size(-1)))[0]
+        logits[logits < filter[:, [-1]]] = float('-inf')
+    if top_p > 0.0:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+        cumulative_probs = torch.cumsum(
+            F.softmax(sorted_logits, dim=-1), dim=-1)
+        filter = cumulative_probs > top_p
+        filter[..., 1:] = filter[..., :-1].clone()
+        filter[..., 0] = 0
+        indices_to_remove = filter.scatter(1, sorted_indices, filter)
+        logits[indices_to_remove] = float('-inf')
+    return logits
+
+
+def norm_logits(logits: torch.Tensor, temperature: float, top_k: float, top_p: float) -> torch.Tensor:
+    """
+
+    Args:
+        logits (torch.Tensor): shape (1, vocab)
+        temperature (float): temperature
+        top_k (float): top_k
+        top_p (float): top_p
+
+    Returns:
+        torch.Tensor: next token with shape as (batch, 1)
+    """
+    assert logits.dim() == 2
+    logits = logits / temperature
+    logits = top_k_top_p_filter(logits, top_k=top_k, top_p=top_p)
+    probs = F.softmax(logits, dim=1)
+    return probs
+
+
+def sample(probs: torch.Tensor, num_samples: int = 1):
+    idx_next = torch.multinomial(probs, num_samples=num_samples)
+    if (idx_next.item() == 0):
+        raise RuntimeError
+    return idx_next
+
+
+def _debug_show_kvcache(past_key_values):
+    if past_key_values is None:
+        return
+    for elem in past_key_values:
+        k, v = elem
+        print(f"kv cache: k shape {k.shape}, v shape {v.shape}")
+        break
+
+
+def trim_kv_cache(past_key_values: Tuple[Tuple[torch.Tensor, torch.Tensor]], q: torch.Tensor, end_pos: int):
+    """
+    trim the KV cache to the end_pos
+
+    Args:
+        past_key_values (Tuple): KV Cache
+        end_pos (int): the position of the valid prefix
+
+    Returns:
+        Tuple: the trimmed KV Cache
+    """
+    past_key_values_trimmed = []
+    for kv in past_key_values:
+        k, v = kv
+        # NOTE() the indexing is specific for bloom. This won't work for other models
+        # For example llama k, v should be (batch, num_head, seq_len, hidden_dim)
+        k = k[:, :, :end_pos]
+        v = v[:, :end_pos, :]
+        kv_trimmed = (k, v)
+        past_key_values_trimmed.append(kv_trimmed)
+
+    q = q[:, :end_pos, :]
+    return past_key_values_trimmed, q
+
+
+def forward_with_kvcache(model, input_ids, past_key_values, cached_q, temperature, top_k, top_p, use_debug=False):
+    if past_key_values is None:
+        assert cached_q is None
+        # the first forward returns the prompt's logits
+        outputs = model(input_ids)
+        cached_q = outputs.logits
+        for i in range(cached_q.shape[-2]):
+            cached_q[:, i, :] = norm_logits(cached_q[:, i, :], temperature, top_k, top_p)
+        last_q = cached_q[:, -1, :]
+    else:
+        # return the last token's logits
+        cached_len = 0
+        for kv in past_key_values:
+            k, v = kv
+            cached_len = k.shape[2]
+
+        last_input_id = input_ids[:, cached_len:]
+        if last_input_id.dim() == 1:
+            last_input_id = torch.unsqueeze(last_input_id, 0)
+
+        if use_debug:
+            print(f"last_input_id shape {last_input_id.shape}")
+            _debug_show_kvcache(past_key_values)
+
+        outputs = model(last_input_id, past_key_values=past_key_values, use_cache=True)
+
+        not_cached_q = outputs.logits
+        if not_cached_q.dim() == 2:
+            not_cached_q = torch.unsqueeze(not_cached_q, 0)
+
+        for i in range(not_cached_q.shape[-2]):
+            not_cached_q[:, i, :] = norm_logits(not_cached_q[:, i, :], temperature, top_k, top_p)
+
+        if cached_q is not None:
+            cached_q = torch.cat([cached_q, not_cached_q], dim=1)
+        last_q = not_cached_q[:, -1, :]
+
+    return last_q, outputs.past_key_values, cached_q
+
+
+@torch.no_grad()
+def autoregressive_sampling(x: torch.Tensor, model: torch.nn.Module, N: int,
+                            temperature: float = 1, top_k: int = 0, top_p: float = 0):
+    n = len(x)
+    T = len(x) + N
+
+    past_key_values = None
+    with tqdm(total=N, desc="autoregressive sampling") as pbar:
+        while n < T:
+            # outputs = model(x)
+            last_q, past_key_values, _ = forward_with_kvcache(model, x, past_key_values, None, temperature, top_k,
+                                                              top_p)
+            # logits = outputs.logits[::, -1, :]
+            # past_key_values = outputs.past_key_values
+            idx_next = sample(last_q)
+            x = torch.cat((x, idx_next), dim=1)
+            n += 1
+            pbar.update(1)
+
+    return x
+
+
+def max_fn(x):
+    """
+        norm(max (x, 0))
+    """
+    x_max = torch.where(x > 0, x, torch.zeros_like(x))
+    x_max_sum = torch.sum(x_max, dim=1, keepdim=True)
+    return x_max / x_max_sum
+
+
+def generate_with_kvcache(prefix: torch.Tensor,
+                          gamma: int,
+                          approx_model: torch.nn.Module,
+                          temperature: float,
+                          top_k: float,
+                          top_p: float,
+                          past_key_values: Tuple[Tuple[torch.Tensor, torch.Tensor]] = None,
+                          cached_q=None,
+                          use_debug=False) -> Tuple[
+    torch.Tensor, torch.Tensor, Tuple[Tuple[torch.Tensor, torch.Tensor]]]:
+    """ forward the model gamma times
+
+    Args:
+        prefix (torch.Tensor): the prefix
+        gamma (int): how many times approx guesses
+        approx_model (torch.nn.Module): an approx model
+        temperature (float): temp for sampling
+        top_k (float): top_k for sampling
+        top_p (float): top_p for sampling
+        past_key_values : valid kv cache
+        cached_q: valid probability distribution of vocab on the all of the prefix tokens
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor, Tuple]: prefix+generated tokens, past key value cache, probability distribution of vocab on the all of the tokens
+    """
+    x = prefix
+
+    for _ in range(gamma):
+        q, past_key_values, cached_q = forward_with_kvcache(approx_model, x, past_key_values, cached_q, temperature,
+                                                            top_k, top_p, use_debug)
+        next_tok = sample(q)
+        x = torch.cat((x, next_tok), dim=1)
+
+    return x, past_key_values, cached_q
+
+
+@torch.no_grad()
+def speculative_sampling_v2(prefix: torch.Tensor, approx_model: torch.nn.Module, target_model: torch.nn.Module,
+                            max_len: int, gamma: int = 4,
+                            temperature: float = 1, top_k: int = 0, top_p: float = 0) -> torch.Tensor:
+    """
+    DeepMind version Speculative Sampling.
+    Accelerating Large Language Model Decoding with Speculative Sampling
+    https://arxiv.org/abs/2302.01318
+    No KV Cache Optimization
+
+    Args:
+        x (torch.Tensor): input sequence, (batch, prefix_seqlen), Note that the batch dim is always 1 now.
+        approx_model (torch.nn.Module): approx model, the small one
+        target_model (torch.nn.Module): target model, the large one
+        max_len (int): the max overall generated tokens number.
+        gamma (int): $\gamma$, the token number small model guesses.
+        temperature (float, optional): Defaults to 1.
+        top_k (int, optional): Defaults to 0.
+        top_p (float, optional): Defaults to 0.
+
+    Returns:
+        torch.Tensor: generated tokens (batch, target_seqlen)
+    """
+    seq_len = prefix.shape[1]
+    T = seq_len + max_len
+
+    assert prefix.shape[0] == 1, "input batch size must be 1"
+
+    with tqdm(total=T, desc="speculative sampling") as pbar:
+        while prefix.shape[1] < T:
+            # q = M_q[prefix + x_0, x_1, .., x_(gamma-2)]
+            x = prefix
+            prefix_len = prefix.shape[1]
+            for _ in range(gamma):
+                # p.logits shape (batch, seq, vocab)
+                q = approx_model(x).logits
+                next_tok = sample(norm_logits(q[:, -1, :],
+                                              temperature, top_k, top_p))
+                x = torch.cat((x, next_tok), dim=1)
+
+            # normalize the logits
+            for i in range(q.shape[1]):
+                q[:, i, :] = norm_logits(q[:, i, :],
+                                         temperature, top_k, top_p)
+            # p  = M_p[prefix + x_0, x_0, .., x_(gamma-1)]
+            p = target_model(x).logits
+            for i in range(p.shape[1]):
+                p[:, i, :] = norm_logits(p[:, i, :],
+                                         temperature, top_k, top_p)
+
+            # n the end position of the valid prefix
+            # x = x_[:prefix_len-1] + x_0, ... x_(gamma-1)
+
+            is_all_accept = True
+            n = prefix_len - 1
+            for i in range(gamma):
+                r = torch.rand(1, device=p.device)
+                j = x[:, prefix_len + i]
+
+                if r < torch.min(torch.tensor([1], device=q.device),
+                                 p[:, prefix_len + i - 1, j] / q[:, prefix_len + i - 1, j]):
+                    # accept, and update n
+                    n += 1
+                else:
+                    # reject
+                    t = sample(max_fn(p[:, n, :] - q[:, n, :]))
+                    is_all_accept = False
+                    break
+
+            prefix = x[:, :n + 1]
+
+            if is_all_accept:
+                t = sample(p[:, -1, :])
+
+            prefix = torch.cat((prefix, t), dim=1)
+            pbar.update(n - pbar.n)
+
+    return prefix
+
+
+@torch.no_grad()
+def speculative_sampling(prefix: torch.Tensor, approx_model: torch.nn.Module, target_model: torch.nn.Module,
+                         max_len: int, gamma: int = 4,
+                         temperature: float = 1, top_k: int = 0, top_p: float = 0,
+                         verbose: bool = False) -> torch.Tensor:
+    """
+    Google version Speculative Sampling.
+    https://arxiv.org/pdf/2211.17192.pdf
+
+    Adapted with KV Cache Optimization.
+
+    Args:
+        x (torch.Tensor): input sequence, (batch, prefix_seqlen), Note that the batch dim is always 1 now.
+        approx_model (torch.nn.Module): approx model, the small one
+        target_model (torch.nn.Module): target model, the large one
+        max_len (int): the max overall generated tokens number.
+        gamma (int): $\gamma$, the token number small model guesses.
+        temperature (float, optional): Defaults to 1.
+        top_k (int, optional): Defaults to 0.
+        top_p (float, optional): Defaults to 0.
+
+    Returns:
+        torch.Tensor: generated tokens (batch, target_seqlen)
+    """
+    seq_len = prefix.shape[1]
+    T = seq_len + max_len
+
+    assert prefix.shape[0] == 1, "input batch size must be 1"
+
+    assert approx_model.device == target_model.device
+
+    if verbose:
+        global DECODER
+
+    target_model_past_key_values = None
+    approx_model_past_key_values = None
+    # TODO() we can reduce the volume of q
+    cached_q = None
+    cached_p = None
+    with tqdm(total=T, desc="speculative sampling") as pbar:
+        while prefix.shape[1] < T:
+            # q = M_q[prefix + x_0, x_1, .., x_(gamma-2)]
+            prefix_len = prefix.shape[1]
+
+            x, approx_model_past_key_values, cached_q = generate_with_kvcache(
+                prefix, gamma, approx_model,
+                temperature, top_k, top_p, approx_model_past_key_values, cached_q)
+
+            # q (batch_size, prefix_len+gamma, vocab)
+            # assert q.shape[-2] == gamma, f"q.shape {q.shape} dose not match gamma {gamma}"
+
+            # p  = M_p[prefix + x_0, x_0, .., x_(gamma-1)]
+            _, target_model_past_key_values, cached_p = forward_with_kvcache(
+                target_model,
+                x,
+                target_model_past_key_values, cached_p,
+                temperature, top_k, top_p,
+                use_debug=False)
+
+            # n the end position of the valid prefix
+            # x = x_[:prefix_len-1] + x_0, ... x_(gamma-1)
+            n = prefix_len + gamma - 1
+            for i in range(gamma):
+                r = torch.rand(1, device=cached_q.device)
+                j = x[:, prefix_len + i]
+
+                # print(f"cached_q {cached_q.shape}, p {cached_p.shape} prefix_len {prefix_len}")
+                if r > (cached_p[:, prefix_len + i - 1, j]) / (cached_q[:, prefix_len + i - 1, j]):
+                    # reject
+                    n = prefix_len + i - 1
+                    break
+
+                if verbose:
+                    print(f"approx guess accepted {j[0]}: \033[31m{DECODER.decode(torch.tensor([j]))}\033[0m")
+
+            # print(f"n : {n}, i : {i}, prefix_len + gamma - 1: {prefix_len + gamma - 1}")
+            assert n >= prefix_len - 1, f"n {n}, prefix_len {prefix_len}"
+            prefix = x[:, :n + 1]
+            approx_model_past_key_values, cached_q = trim_kv_cache(approx_model_past_key_values, cached_q, n + 1)
+            assert cached_q.shape[-2] <= n + 1, f"cached_q.shape {cached_q.shape}, n {n}"
+
+            if n < prefix_len + gamma - 1:
+                # reject someone, sample from the pos n
+                t = sample(max_fn(cached_p[:, n, :] - cached_q[:, n, :]))
+                if verbose:
+                    print(f"target resamples {n}: \033[34m{DECODER.decode(t)}\033[0m")
+
+                # target_model_past_key_values = None
+                # cached_p = None
+                target_model_past_key_values, cached_p = trim_kv_cache(target_model_past_key_values, cached_p, n + 1)
+            else:
+                # all approx model decoding accepted
+                assert n == cached_p.shape[1] - 1
+                t = sample(cached_p[:, -1, :])
+                if verbose:
+                    print(f"target samples {n}: \033[35m{DECODER.decode(t)}\033[0m")
+                target_model_past_key_values, cached_p = trim_kv_cache(target_model_past_key_values, cached_p, n + 2)
+
+            prefix = torch.cat((prefix, t), dim=1)
+
+            if not verbose:
+                pbar.update(n - pbar.n)
+
+    return prefix


### PR DESCRIPTION
close #199

Do you have any idea why speculative sampling result is different? It gives completely random results in every run!
 I thought speculative sampling was an alternative to Optimizer, am I wrong? any suggestion, idea? Please let me know!

Normal Result:
```
'NoneType' object has no attribute 'cadam32bit_grad_fp32'
Project Root: /Users/syny/kafamagore/LLM-VM/src/llm_vm
Using model: opt
Running with an empty context
{'completion': '\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA is Washington, DC.\n\nThe capital of the USA', 'status': 200}
```

Speculative Sampling result:
```
'NoneType' object has no attribute 'cadam32bit_grad_fp32'
/Users/syny/kafamagore/LLM-VM/.venv/lib/python3.10/site-packages/bitsandbytes/cextension.py:34: UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
  warn("The installed version of bitsandbytes was compiled without GPU support. "
Project Root: /Users/syny/kafamagore/LLM-VM/src/llm_vm
Using model: opt
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
	- Avoid using `tokenizers` before the fork if possible
	- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
speculative sampling: 100%|█████████▉| 264/265 [02:07<00:00,  2.07it/s]
{'completion': "What is the capital of the USA? (Gregsergio, first person to say that.)  Edit: The wikipedia says it's New York City, so actually Washington D.C.  Edit 2: Did you check the wiki? They have an indication as to how it formed.\nNew York City is the capital of the USA; parts of what you say are in New York, particularly the boroughs. Washington D. C., narrowly speaking isn't a part of Washington, DC; the District is either D.C. or New York.  After the last I checked, you are correct, that I didn't check the wiki, so thanks!\nSorry, based on the wikipedia form, I assumed that the crown prince of Washington would be the queen, since she was holding it together during the Dark Ages. But if you're talking about Danzig, it's not a part of D.C., which wasn't anything to do with the time period, but different time period. Is Jerusalem the capital of Israel? A friend in Israel is Jewish, and he said Jerusalem, not Jerusalem.\nOh God, now I get it. I start reading in HS again and I assumed in high school i was 7 at the time. Thanks a lot!Not a case of 'they", 'status': 200}
```