### PR TITLE
retry with exponential backoff when `openai.error.RateLimitError`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "outlines>=0.0.1",
     "en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.6.0/en_core_web_md-3.6.0-py3-none-any.whl",
     "gradio>=3.42.0",  # Specify the latest version of gradio
+    "backoff>=2.2.1",
 ]
 
 [project.optional-dependencies]

--- a/src/llm_vm/completion/data_synthesis.py
+++ b/src/llm_vm/completion/data_synthesis.py
@@ -2,6 +2,7 @@ import json
 import sys
 from sentence_transformers import SentenceTransformer, util
 import openai
+import backoff 
 import os
 import time
 import pickle
@@ -47,6 +48,7 @@ class DataSynthesis:
         pickle.dump(datapoints,new_file)
         return datapoints
     
+    @backoff.on_exception(backoff.expo, openai.error.RateLimitError)
     def generate_example(self, final_prompt, openai_key, example_delim = "<END>", model="gpt-4",max_tokens = 1000,temperature = 1,regex = None,type = None,choices = None, grammar_type = None):
         openai.api_key=openai_key
         cur_prompt = [{'role': "system", 'content' : final_prompt}]


### PR DESCRIPTION
Closes #147 

Retry with exponential backoff when `openai.error.RateLimitError` during generating examples using data_synthesizer instead of throwing an exception and exiting.

Uses `backoff` library for implementation.