### PR TITLE
Include beartype dependency and pin its version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "xdg>=6.0.0",
     "accelerate>=0.21.0",
     "transformers>=4.31.0",
+    "beartype==0.15.0",
     "ctransformers>=0.2.24",
     "flask>=2.3.2",
     "flask_cors>=4.0.0",


### PR DESCRIPTION
## Summary of changes

PyTorch has a dependency on [beartype](https://github.com/beartype/beartype) that was previously unpinned.  A change to that dependency led to a series of problems.  [The next release of PyTorch will include a pinned version that resolves the issue reported in #276](https://github.com/pytorch/pytorch/pull/109510).  In the interim, adding the transitive dependency here will resolve #276 .