### PR TITLE
add bash script for linux

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python -m venv llm
+source llm/bin/activate
+python -m pip install -e ."[dev]"


### PR DESCRIPTION
So, I using Linux and `setup.sh` did not work for me. so I made a pr to add documentation to the readme.

Running `./setup.sh`  gave me the error:

```
* Checking OS..
bash: ./bin/setup_linux.sh: No such file or directory
```

But the changes in this pr allowed me to install llm-vm on my linux machine.