### PR TITLE
AttributeError: module 'openai' has no attribute 'error' #390 - corre…

### DIFF
--- a/src/llm_vm/completion/data_synthesis.py
+++ b/src/llm_vm/completion/data_synthesis.py
@@ -54,7 +54,7 @@ class DataSynthesis:
         pickle.dump(datapoints_list, new_file)
         return datapoints_list
     
-    @backoff.on_exception(backoff.expo, openai.error.RateLimitError)
+    @backoff.on_exception(backoff.expo, openai.RateLimitError)
     def generate_examples(self, final_prompt, openai_key, example_delim="<END>", model="gpt-4", max_tokens=1000, temperature=1, completion=None, call_big_kwargs={}):
         openai.api_key = openai_key
         cur_prompt = [{'role': "system", 'content': final_prompt}]


### PR DESCRIPTION
…cting reference to RateLimitError

This is the first part of a fix for this issue, caused when there is not enough backoff to stay under the rate limit 

-- The openai library interface changed, so that now RateLimitError is at the top level of the module: openai.RateLimitError. This is the only place in the entire codebase where the old reference exists.