### PR TITLE
ability to load `.pt` file into the student model

### DIFF
--- a/src/llm_vm/client.py
+++ b/src/llm_vm/client.py
@@ -198,8 +198,11 @@ class Client:
             return {"status":0, "resp": str(e)}
         return {"completion":completion, "status": 200}
 
-    def load_finetune(self, model_filename=None):
-        self.teacher.load_finetune(model_filename)
+    def load_finetune(self, model_filename=None, small_model=False):
+        if small_model:
+            self.student.load_finetune(model_filename)
+        else:
+            self.teacher.load_finetune(model_filename)
 
     def set_pinecone_db(self, api_key, env_name):
         self.vector_db = PineconeDB(api_key, env_name)


### PR DESCRIPTION
closes #402

added a flag `small_model` to the `client.load_finetune` method to specify loading the `.pt` file between the teacher model or the student model

```
# loads the .pt file into the teacher model by default
client.load_finetune(model_filename)

# loads the .pt file into the student model when `small_model` flag is set to `True`
client.load_finetune(model_filename, small_model=True)
```

this allows for existing code to still work without breaking

cc: @VictorOdede @abhigya-sodani 