### PR TITLE
feat: nix package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ settings.toml
 *.pkl
 
 .idea/
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixgl": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1685908677,
+        "narHash": "sha256-E4zUPEUFyVWjVm45zICaHRpfGepfkE9Z2OECV9HXfA4=",
+        "owner": "guibou",
+        "repo": "nixGL",
+        "rev": "489d6b095ab9d289fe11af0219a9ff00fe87c7c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "guibou",
+        "repo": "nixGL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660551188,
+        "narHash": "sha256-a1LARMMYQ8DPx1BgoI/UN4bXe12hhZkCNqdxNi6uS0g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "441dc5d512153039f19ef198e662e4f3dbb9fd65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1703255338,
+        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixgl": "nixgl",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Anarchy AI - A highly optimized and opinionated backend for running LLMs";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixgl.url = "github:guibou/nixGL";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+  nixConfig.extra-substituters = [
+    "https://cuda-maintainers.cachix.org"
+    "https://nixos-rocm.cachix.org"
+  ];
+  nixConfig.extra-trusted-public-keys = [
+    "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
+    "nixos-rocm.cachix.org-1:VEpsf7pRIijjd8csKjFNBGzkBqOmw8H9PRmgAq14LnE="
+  ];
+  outputs = {
+    self,
+    nixpkgs,
+    flake-parts,
+    nixgl,
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;}
+    {
+      systems = ["x86_64-linux"];
+      imports = [
+        ./nix/nixpkgs-instances.nix
+        ./nix/apps.nix
+        ./nix/devshells.nix
+      ];
+      perSystem = {
+        config,
+        pkgs,
+        pkgsCuda,
+        pkgsRocm,
+        ...
+      }: {
+        packages = {
+          default = (pkgs.callPackage ./nix {}).llm-vm;
+          cuda = (pkgsCuda.callPackage ./nix {}).llm-vm;
+          rocm = (pkgsRocm.callPackage ./nix {}).llm-vm;
+        };
+      };
+    };
+}

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,54 @@
+{
+  perSystem = {
+    config,
+    lib,
+    pkgs,
+    pkgsCuda,
+    pkgsRocm,
+    ...
+  }: {
+    apps = let
+      wrapNixGL = pkgs: backend: app: name: {
+        type = "app";
+        program = let
+          p = pkgs.writeShellScriptBin "${name}-${backend}" ''
+
+            #!/bin/sh
+            ${pkgs.nixgl.auto.nixGLDefault}/bin/nixGL ${app}/bin/${name} "$@"
+          '';
+        in "${p}/bin/${name}-${backend}";
+      };
+
+      mkDefault = name: {
+        type = "app";
+        program = "${config.packages.default}/bin/${name}";
+      };
+
+      wrappedPackagesFns = {
+        cuda = name: backend: wrapNixGL pkgsCuda backend config.packages.cuda name;
+        rocm = name: backend: wrapNixGL pkgsRocm backend config.packages.rocm name;
+      };
+
+      binaries = [
+        "llm_vm_run_agent"
+        "llm_vm_run_agent_backwards_chaining"
+        "llm_vm_run_agent_flat"
+        "llm_vm_server"
+        "llm_vm_run_agent_rebel"
+      ];
+    in
+      (lib.foldl' (a: b: a // b) {} (builtins.map (name:
+        lib.mapAttrs'
+        (backend: f:
+          lib.nameValuePair "${name}-${backend}" (f name backend))
+        wrappedPackagesFns)
+      binaries))
+      // (lib.genAttrs binaries mkDefault)
+      // {
+        default = {
+          type = "app";
+          program = "${config.packages.default}/bin/llm_vm_server";
+        };
+      };
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  callPackage = lib.callPackageWith (pkgs // pkgs.python3Packages // packages);
+  packages = {
+    ctransformers = callPackage ./packages/ctransformers {};
+    dynaconf = callPackage ./packages/dynaconf {};
+    interegular = callPackage ./packages/interegular {};
+    vellum-ai = callPackage ./packages/vellum-ai {};
+    llama-index = callPackage ./packages/llama-index {};
+    outlines = callPackage ./packages/outlines {};
+    perscache = callPackage ./packages/perscache {};
+    trl = callPackage ./packages/trl {};
+    tyro = callPackage ./packages/tyro {};
+    llm-vm = callPackage ./package.nix {};
+  };
+in
+  packages

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -1,0 +1,34 @@
+{inputs, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    pkgsCuda,
+    pkgsRocm,
+    ...
+  }: {
+    devShells = {
+      default =
+        (pkgs.python3.withPackages
+          (ps: [ps.pytest config.packages.default]))
+        .env;
+      cuda = pkgsCuda.mkShell {
+        packages = [
+          pkgsCuda.nixgl.auto.nixGLDefault
+          (pkgsCuda.python3.withPackages (ps: [config.packages.cuda ps.pytest]))
+        ];
+        shellHook = ''
+          export LD_LIBRARY_PATH=$(nixGL printenv LD_LIBRARY_PATH):$LD_LIBRARY_PATH
+        '';
+      };
+      rocm = pkgsRocm.mkShell {
+        packages = [
+          pkgsRocm.nixgl.auto.nixGLDefault
+          (pkgsRocm.python3.withPackages (ps: [config.packages.rocm ps.pytest]))
+        ];
+        shellHook = ''
+          export LD_LIBRARY_PATH=$(nixGL printenv LD_LIBRARY_PATH):$LD_LIBRARY_PATH
+        '';
+      };
+    };
+  };
+}

--- a/nix/nixpkgs-instances.nix
+++ b/nix/nixpkgs-instances.nix
@@ -1,0 +1,27 @@
+{inputs, ...}: {
+  # The _module.args definitions are passed on to modules as arguments. E.g.
+  # the module `{ pkgs ... }: { /* config */ }` implicitly uses
+  # `_module.args.pkgs` (defined in this case by flake-parts).
+  perSystem = {system, ...}: {
+    _module.args = {
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [inputs.nixgl.overlay];
+      };
+      pkgsCuda = import inputs.nixpkgs {
+        inherit system;
+        # Ensure dependencies use CUDA consistently (e.g. that openmpi, ucc,
+        # and ucx are built with CUDA support)
+        config.cudaSupport = true;
+        overlays = [inputs.nixgl.overlay];
+        config.allowUnfree = true;
+      };
+      # Ensure dependencies use ROCm consistently
+      pkgsRocm = import inputs.nixpkgs {
+        inherit system;
+        overlays = [inputs.nixgl.overlay];
+        config.rocmSupport = true;
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  setuptools,
+  dynaconf,
+  numpy,
+  watchdog,
+  xdg,
+  accelerate,
+  transformers,
+  ctransformers,
+  flask,
+  flask-cors,
+  llama-index,
+  levenshtein,
+  beautifulsoup4,
+  sentencepiece,
+  sentence-transformers,
+  requests,
+  spacy,
+  outlines,
+  gradio,
+  backoff,
+  peft,
+  pinecone-client,
+  pypdf2,
+  trl,
+  weaviate-client,
+  python-dotenv,
+}:
+buildPythonPackage {
+  pname = "llm_vm";
+  version = "0.1.55";
+  format = "pyproject";
+  disabled = pythonOlder "3.10";
+  src = ../.;
+  buildInputs = [
+    setuptools
+  ];
+  propagatedBuildInputs = [
+    dynaconf
+    numpy
+    watchdog
+    xdg
+    accelerate
+    transformers
+    ctransformers
+    flask
+    flask-cors
+    llama-index
+    levenshtein
+    beautifulsoup4
+    sentencepiece
+    sentence-transformers
+    requests
+    spacy
+    outlines
+    gradio
+    backoff
+    peft
+    pinecone-client
+    pypdf2
+    trl
+    weaviate-client
+    python-dotenv
+  ];
+
+  # Tests use HuggingFace which attempts to create directories and access the internet
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Strongly typed, zero-effort CLI interfaces";
+    homepage = "https://github.com/brentyi/tyro";
+    license = licenses.mit;
+    maintainers = let
+      collinarnett = {
+        name = "Collin Arnett";
+        email = "collin@arnett.it";
+        github = "collinarnett";
+        githubId = 38230482;
+      };
+    in [collinarnett];
+  };
+}

--- a/nix/packages/ctransformers/default.nix
+++ b/nix/packages/ctransformers/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  stdenv,
+  fetchFromGitHub,
+  darwin,
+  cmake,
+  huggingface-hub,
+  py-cpuinfo,
+  scikit-build,
+  pytestCheckHook,
+}: let
+  name = "ctransformers";
+  version = "0.2.24";
+  isM1 = stdenv.isAarch64 && stdenv.isDarwin;
+  osSpecific =
+    if isM1
+    then with darwin.apple_sdk_11_0.frameworks; [Accelerate]
+    else if stdenv.isDarwin
+    then with darwin.apple_sdk.frameworks; [Accelerate CoreGraphics CoreVideo]
+    else [];
+in
+  buildPythonPackage {
+    inherit version;
+    pname = name;
+    format = "setuptools";
+
+    src = fetchFromGitHub {
+      owner = "marella";
+      repo = name;
+      rev = "refs/tags/v${version}";
+      hash = "sha256-Ub+1z7A4kabQiuL+E2UlHzwY6dFZHSYR4VuFk9ancTY=";
+      fetchSubmodules = true;
+    };
+
+    propagatedBuildInputs = [
+      huggingface-hub
+      py-cpuinfo
+    ];
+    dontUseCmakeConfigure = true;
+
+    nativeBuildInputs = [
+      cmake
+      scikit-build
+    ];
+    buildInputs = osSpecific;
+    nativeCheckInputs = [pytestCheckHook];
+    pythonImportsCheck = ["ctransformers"];
+    disabledTestPaths = ["tests/test_model.py"];
+    pytestFlagsArray = ["--lib basic"];
+    meta = with lib; {
+      description = "Python bindings for the Transformer models implemented in C/C++ using GGML library";
+      homepage = "https://github.com/marella/ctransformers";
+      license = licenses.mit;
+    };
+  }

--- a/nix/packages/dynaconf/default.nix
+++ b/nix/packages/dynaconf/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  pytestCheckHook,
+  setuptools,
+  flask,
+  django,
+  configobj,
+  redis,
+  hvac,
+  ruamel-yaml,
+}:
+buildPythonPackage rec {
+  pname = "dynaconf";
+  version = "3.2.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-LmreuqWH9N+SQaFqS+w/2lIRVNJrFfMlj951OlkoMbY=";
+  };
+
+  propagatedBuildInputs = [setuptools];
+
+  nativeCheckInputs = [pytestCheckHook configobj flask django];
+  passthru.optional-dependencies = {
+    ini = [configobj];
+    configobj = [configobj];
+    yaml = [ruamel-yaml];
+    vault = [hvac];
+    redis = [redis];
+    all = [redis configobj hvac ruamel-yaml];
+  };
+
+  disabledTestPaths = ["tests/test_redis.py" "tests/test_vault.py"];
+
+  pythonImportsCheck = [
+    "dynaconf"
+  ];
+
+  meta = with lib; {
+    description = "The dynamic configurator for your Python Project";
+    homepage = "https://github.com/dynaconf/dynaconf";
+    license = licenses.mit;
+  };
+}

--- a/nix/packages/interegular/default.nix
+++ b/nix/packages/interegular/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  unittestCheckHook,
+  fetchPypi,
+  setuptools,
+  wheel,
+}:
+buildPythonPackage rec {
+  pname = "interegular";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-6kZFq6zpPZ8500EgVoamC3l3ekPZRACTPv+5yPKQGCU=";
+  };
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+  naitiveCheckInputs = [
+    unittestCheckHook
+  ];
+  #postCheck = ''
+  #  PYTHONPATH=$out/${python.sitePackages}:PYTHONPATH
+  #  python -c "from interegular.fsm import Alphabet"
+  #'';
+  meta = with lib; {
+    homepage = "https://github.com/MegaIng/interegular";
+    description = "regex intersection checker";
+    license = licenses.mit;
+  };
+}

--- a/nix/packages/llama-index/default.nix
+++ b/nix/packages/llama-index/default.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonRelaxDepsHook,
+  poetry-core,
+  nltk,
+  pillow,
+  beautifulsoup4,
+  faiss,
+  fsspec,
+  langchain,
+  nest-asyncio,
+  numpy,
+  openai,
+  pandas,
+  sqlalchemy,
+  tiktoken,
+  vellum-ai,
+}:
+buildPythonPackage rec {
+  pname = "llama-index";
+  version = "0.9.17";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "run-llama";
+    repo = "llama_index";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-bmqucvIYStRak0qBWG0XihSm+zJqDo8GrhbViIK+ffU=";
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    poetry-core
+  ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    nltk
+    pillow
+  ];
+
+  pythonRelaxDeps = [
+    "fsspec"
+    "langchain"
+    "sqlalchemy"
+  ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    faiss
+    fsspec
+    langchain
+    nest-asyncio
+    numpy
+    openai
+    pandas
+    sqlalchemy
+    tiktoken
+    vellum-ai
+  ];
+
+  disabledTestPaths = [
+    "tests/agent/openai/test_openai_agent.py"
+    "tests/agent/react/test_react_agent.py"
+    "tests/callbacks/test_token_counter.py"
+    "tests/chat_engine/test_condense_question.py"
+    "tests/chat_engine/test_simple.py"
+    "tests/embeddings/test_base.py"
+    "tests/embeddings/test_utils.py"
+    "tests/indices/document_summary/test_index.py"
+    "tests/indices/document_summary/test_retrievers.py"
+    "tests/indices/empty/test_base.py"
+    "tests/indices/keyword_table/test_base.py"
+    "tests/indices/keyword_table/test_retrievers.py"
+    "tests/indices/keyword_table/test_utils.py"
+    "tests/indices/knowledge_graph/test_base.py"
+    "tests/indices/knowledge_graph/test_retrievers.py"
+    "tests/indices/list/test_index.py"
+    "tests/indices/list/test_retrievers.py"
+    "tests/indices/postprocessor/test_base.py"
+    "tests/indices/postprocessor/test_llm_rerank.py"
+    "tests/indices/postprocessor/test_optimizer.py"
+    "tests/indices/query/query_transform/test_base.py"
+    "tests/indices/query/test_compose_vector.py"
+    "tests/indices/query/test_compose.py"
+    "tests/indices/query/test_query_bundle.py"
+    "tests/indices/response/test_response_builder.py"
+    "tests/indices/response/test_tree_summarize.py"
+    "tests/indices/struct_store/test_base.py"
+    "tests/indices/struct_store/test_json_query.py"
+    "tests/indices/struct_store/test_sql_query.py"
+    "tests/indices/test_loading_graph.py"
+    "tests/indices/test_loading.py"
+    "tests/indices/test_node_utils.py"
+    "tests/indices/test_prompt_helper.py"
+    "tests/indices/test_utils.py"
+    "tests/indices/tree/test_embedding_retriever.py"
+    "tests/indices/tree/test_index.py"
+    "tests/indices/tree/test_retrievers.py"
+    "tests/indices/vector_store/test_deeplake.py"
+    "tests/indices/vector_store/test_faiss.py"
+    "tests/indices/vector_store/test_pinecone.py"
+    "tests/indices/vector_store/test_retrievers.py"
+    "tests/indices/vector_store/test_simple.py"
+    "tests/llm_predictor/vellum/test_predictor.py"
+    "tests/llm_predictor/vellum/test_prompt_registry.py"
+    "tests/llms/test_openai.py"
+    "tests/llms/test_palm.py"
+    "tests/memory/test_chat_memory_buffer.py"
+    "tests/objects/test_base.py"
+    "tests/playground/test_base.py"
+    "tests/query_engine/test_pandas.py"
+    "tests/question_gen/test_llm_generators.py"
+    "tests/selectors/test_llm_selectors.py"
+    "tests/test_utils.py"
+    "tests/text_splitter/test_code_splitter.py"
+    "tests/text_splitter/test_sentence_splitter.py"
+    "tests/token_predictor/test_base.py"
+    "tests/tools/test_ondemand_loader.py"
+  ];
+
+  # pythonImportsCheck = [ "llama_index" ];
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Interface between LLMs and your data";
+    homepage = "https://github.com/jerryjliu/llama_index";
+    license = licenses.mit;
+  };
+}

--- a/nix/packages/outlines/default.nix
+++ b/nix/packages/outlines/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchPypi,
+  setuptools-scm,
+  jinja2,
+  interegular,
+  lark,
+  nest-asyncio,
+  numpy,
+  perscache,
+  pydantic,
+  scipy,
+  torch,
+  numba,
+  joblib,
+  referencing,
+  jsonschema,
+  requests,
+}:
+buildPythonPackage rec {
+  pname = "outlines";
+
+  version = "0.0.18";
+  disabled = pythonOlder "3.8";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-RMRnCLxT83YUzBY5LiExsXZ32Te5iaX30EYjc/ID4Yc=";
+  };
+  buildInputs = [setuptools-scm];
+
+  propagatedBuildInputs = [
+    jinja2
+    interegular
+    lark
+    nest-asyncio
+    numpy
+    perscache
+    pydantic
+    scipy
+    torch
+    numba
+    joblib
+    referencing
+    jsonschema
+    requests
+  ];
+  doCheck = false;
+  meta = with lib; {
+    description = "Robust (guided) text generation";
+    homepage = "https://github.com/outlines-dev/outlines";
+    license = licenses.mit;
+  };
+}

--- a/nix/packages/perscache/default.nix
+++ b/nix/packages/perscache/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pytestCheckHook,
+  icontract,
+  cloudpickle,
+  beartype,
+  pbr,
+  pyyaml,
+  pyarrow,
+  pandas,
+  gcsfs,
+}:
+buildPythonPackage rec {
+  pname = "perscache";
+  version = "0.6.1";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-G7L19nuMwTeyxaLMvnx6Pm3F6acrzzVWiaKp8qRRMEc=";
+  };
+  nativeBuildInputs = [pbr];
+  propagatedBuildInputs = [
+    icontract
+    cloudpickle
+    beartype
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyyaml
+    pandas
+    pyarrow
+    gcsfs
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/leshchenko1979/perscache";
+    description = "persistently cache results of functions (or callables in general) using decorators.";
+    license = licenses.mit;
+  };
+}

--- a/nix/packages/trl/default.nix
+++ b/nix/packages/trl/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  datasets,
+  torch,
+  tqdm,
+  transformers,
+  accelerate,
+  peft,
+  tyro,
+}:
+buildPythonPackage rec {
+  pname = "trl";
+  version = "0.7.4";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-wUmKuA893VWvapmwCl+YwdIu/8H5KLVN42NGQrXKljA=";
+  };
+
+  propagatedBuildInputs = [
+    datasets
+    torch
+    tqdm
+    transformers
+    accelerate
+    peft
+    tyro
+  ];
+
+  doCheck = false;
+  meta = with lib; {
+    description = "Full stack transformer language models with reinforcement learning.";
+    homepage = "https://github.com/huggingface/trl";
+    license = licenses.asl20;
+  };
+}

--- a/nix/packages/tyro/default.nix
+++ b/nix/packages/tyro/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  docstring-parser,
+  typing-extensions,
+  backports-cached-property,
+  colorama,
+  rich,
+  shtab,
+}:
+buildPythonPackage rec {
+  pname = "tyro";
+  version = "0.6.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+  src = fetchFromGitHub {
+    owner = "brentyi";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-7FZ22CsyNSVN3Nr2BH7GxKLgmNjN9s/34j+vbzvF2aA=";
+  };
+
+  propagatedBuildInputs = [
+    docstring-parser
+    typing-extensions
+    backports-cached-property
+    colorama
+    rich
+    shtab
+  ];
+
+  doCheck = false;
+  meta = with lib; {
+    description = "Strongly typed, zero-effort CLI interfaces";
+    homepage = "https://github.com/brentyi/tyro";
+    license = licenses.mit;
+  };
+}

--- a/nix/packages/vellum-ai/default.nix
+++ b/nix/packages/vellum-ai/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  pythonRelaxDepsHook,
+  poetry-core,
+  httpx,
+  pydantic,
+}:
+buildPythonPackage rec {
+  pname = "vellum-ai";
+  version = "0.0.30";
+  format = "pyproject";
+
+  src = fetchPypi {
+    pname = "vellum_ai";
+    inherit version;
+    hash = "sha256-iWJtl4WDeXqrCFjDHBBEgkG/PcqLfiJ9QkA92QPlQrY=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "httpx"
+  ];
+
+  propagatedBuildInputs = [
+    httpx
+    pydantic
+  ];
+
+  pythonImportsCheck = ["vellum"];
+
+  meta = {
+    description = "Product development platform for AI";
+    homepage = "https://www.vellum.ai/";
+  };
+}


### PR DESCRIPTION
This PR adds Nix as a method of installing and running LLM-VM. With this PR, as long as the [flake experimental feature is enabled with Nix](https://nixos.org/manual/nix/stable/contributing/experimental-features), users can easily run the LLM-VM server with:

```shell
$ nix run github:collinarnett/LLM-VM/nix
```

Users can also run the server with cuda support baked in:
```shell
$ nix run --impure github:collinarnett/LLM-VM/nix#llm_vm_server-cuda
```
(the impure is needed here in order for [nixGL](https://github.com/nix-community/nixGL) to find the host nvidia drivers)

Developers also benefit from this PR with the ability to start a shell with a python environment including LLM-VM.

```shell
$ nix develop github:collinarnett/LLM-VM/nix                    

[collin@vampire:~]$ python
Python 3.11.6 (main, Oct  2 2023, 13:45:54) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from llm_vm.client import Client
```

From here tests can be run by starting the server with the first command then running the tests in the developer shell.

In total, the following outputs are provided.
```shell
$ nix flake show github:collinarnett/LLM-VM/nix
github:collinarnett/LLM-VM/2cb0b872c4cbec7ea655c6bb4ec178d6e69f9bd2
├───apps
│   └───x86_64-linux
│       ├───default: app
│       ├───llm_vm_run_agent: app
│       ├───llm_vm_run_agent-cuda: app
│       ├───llm_vm_run_agent-rocm: app
│       ├───llm_vm_run_agent_backwards_chaining: app
│       ├───llm_vm_run_agent_backwards_chaining-cuda: app
│       ├───llm_vm_run_agent_backwards_chaining-rocm: app
│       ├───llm_vm_run_agent_flat: app
│       ├───llm_vm_run_agent_flat-cuda: app
│       ├───llm_vm_run_agent_flat-rocm: app
│       ├───llm_vm_run_agent_rebel: app
│       ├───llm_vm_run_agent_rebel-cuda: app
│       ├───llm_vm_run_agent_rebel-rocm: app
│       ├───llm_vm_server: app
│       ├───llm_vm_server-cuda: app
│       └───llm_vm_server-rocm: app
├───devShells
│   └───x86_64-linux
│       ├───cuda: development environment 'nix-shell'
│       ├───default: development environment 'interactive-python3-3.11.6-environment'
│       └───rocm: development environment 'nix-shell'
└───packages
    └───x86_64-linux
        ├───cuda: package 'python3.11-llm_vm-0.1.55'
        ├───default: package 'python3.11-llm_vm-0.1.55'
        └───rocm: package 'python3.11-llm_vm-0.1.55'
```

I would be grateful if others could review this PR by installing nix via the [The Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer) and running the commands I included above. I do not have a rocm enabled video card so I would appreciate for those that do to leave their feedback.

Also let me know your general experience. There may be things I can do to make things better. 
 

