### PR TITLE
Added caching for repititive requests on the `/v1/complete` endpoint

### DIFF
--- a/src/llm_vm/server/cache.py
+++ b/src/llm_vm/server/cache.py
@@ -1,0 +1,16 @@
+from flask_caching import Cache
+from flask import request
+
+def make_cache_key(*args, **kwargs):
+    key = request.url + str(request.data)
+    return key
+
+config = {
+    "DEBUG": True,
+    "CACHE_TYPE": "SimpleCache",
+    "CACHE_DEFAULT_TIMEOUT": 30,
+    'CACHE_KEY_PREFIX': 'custom_prefix',
+    'CACHE_KEY_FUNC': make_cache_key
+}
+
+cache = Cache(config=config)

--- a/src/llm_vm/server/main.py
+++ b/src/llm_vm/server/main.py
@@ -9,6 +9,7 @@ import os
 import hashlib
 import sys
 from flask_cors import CORS
+from cache import cache
 from contextlib import contextmanager
 import llm_vm.server.routes as routes
 from llm_vm.config import settings
@@ -16,7 +17,7 @@ from llm_vm.utils.ram import RAMLogger
 
 app = flask.Flask(__name__)
 CORS(app)
-app.config["DEBUG"] = True
+cache.init_app(app)
 
 # Register_blueprint from routes to load API
 app.register_blueprint(routes.bp)

--- a/src/llm_vm/server/routes.py
+++ b/src/llm_vm/server/routes.py
@@ -6,6 +6,7 @@ import openai
 from llm_vm.agents.REBEL import agent
 from llm_vm.client import Client
 from llm_vm.config import settings
+from cache import cache
 # load optimizer for endpoint use
 # optimizer = LocalOptimizer(MIN_TRAIN_EXS=2,openai_key=None)
 
@@ -20,6 +21,7 @@ def home():
     return '''home'''
 
 @bp.route('/v1/complete', methods=['POST'])
+@cache.cached()
 def optimizing_complete():
     rebel_agent = agent.Agent("", [], verbose=1)
     data = json.loads(request.data)


### PR DESCRIPTION
Resolves #362

- Used Flask extension Flask-Caching
- Currently uses a local Python dictionary for caching, but can be updated to use Redis
- Created a `cache.py` file which stores the config for caching and it also prevents circular imports if written directly in `main.py`. Also, it makes the code better organized

I am also planning to resolve the issue #360. But I need to clarify some doubts:
- Where to store the Redis instance configuration? Should we store it as environment variables in .env.example?
- Should I update using Python dictionary for caching to Redis for caching too?