### PR TITLE
Fix typo in guided_completion.py import statement

### DIFF
--- a/src/llm_vm/guided_completion.py
+++ b/src/llm_vm/guided_completion.py
@@ -1,5 +1,5 @@
 import outlines.models as models
-import outlines.text.generate as generate
+import outlines.generate.text as generate
 import torch
 from lark import Lark, Transformer, v_args
 from lark.indenter import PythonIndenter


### PR DESCRIPTION
Closes #440 
`import outlines.text.generate` in line 2 of guided_completion.py should be `import outlines.generate.text` and was throwing an error.